### PR TITLE
Passes class names to Rails middleware over strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+##v2.0.0
+Updated to only work with Rails 5
+
+##v1.0.1

--- a/healthcheck.gemspec
+++ b/healthcheck.gemspec
@@ -5,7 +5,7 @@ require "healthcheck/version"
 Gem::Specification.new do |spec|
   spec.name          = "healthcheck"
   spec.version       = Healthcheck::VERSION
-  spec.authors       = ["Asfand Qazi"]
+  spec.authors       = ["Asfand Qazi", "Lee-Jon Ball"]
   spec.email         = ["ayqazi@gmail.com"]
 
   spec.summary       = %q{Simple healthcheck Rack middleware; supports Rails OOTB}

--- a/lib/healthcheck/railtie.rb
+++ b/lib/healthcheck/railtie.rb
@@ -2,7 +2,7 @@ if Object.constants.include? :Rails
   module Healthcheck
     class Railtie < Rails::Railtie
       initializer "healthcheck.configure_rails_initialization" do
-        Rails.application.middleware.insert_before "Rails::Rack::Logger", "Healthcheck::Middleware"
+        Rails.application.middleware.insert_before Rails::Rack::Logger, Healthcheck::Middleware
       end
     end
   end

--- a/lib/healthcheck/version.rb
+++ b/lib/healthcheck/version.rb
@@ -1,3 +1,3 @@
 module Healthcheck
-  VERSION = "1.0.1"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Middleware can now accept class names over their string counterparts.
A change in ActionPack for Rails 5.0.0 issues a depreciation warning
if strings are passes to it. For example:

This commit enables suppression of these values. But is suited for Rails
5 only.

Change in rails: https://github.com/rails/rails/commit/83b767ce